### PR TITLE
Add Microsoft Entra External ID to recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": ["ms-azuretools.ms-entra"]
+  }
+  


### PR DESCRIPTION
This PR adds Microsoft Entra External ID as a recommended extension in the extensions.json file.